### PR TITLE
Use the fontawesome library feature instead of local import

### DIFF
--- a/src/components/device/alert/alert.component.js
+++ b/src/components/device/alert/alert.component.js
@@ -17,7 +17,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExclamationTriangle } from '@fortawesome/fontawesome-free-solid';
 
 export default class Alert extends React.Component {
   render() {
@@ -25,7 +24,7 @@ export default class Alert extends React.Component {
 
     return (
       <div className="alert alert-warning alert-dismissible fade show" role="alert">
-        <FontAwesomeIcon icon={faExclamationTriangle} />
+        <FontAwesomeIcon icon="exclamation-triangle" />
         <strong> {device.name} Error!</strong> {error.message}
         <button type="button" className="close" data-dismiss="alert" aria-label="Close">
           <span aria-hidden="true">&times;</span>

--- a/src/components/device/chart/info/info.component.js
+++ b/src/components/device/chart/info/info.component.js
@@ -17,7 +17,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faInfoCircle } from '@fortawesome/fontawesome-free-solid';
 import InfoModal from '../info-modal/info-modal.component';
 
 export default class Info extends React.Component {
@@ -29,7 +28,7 @@ export default class Info extends React.Component {
         <div className="col">
 
           <div className="btn btn-link" data-toggle="modal" data-target={`#${project.key}-chart-info`}>
-            <FontAwesomeIcon icon={faInfoCircle} />
+            <FontAwesomeIcon icon="info-circle" />
             <span className="ml-2">Information about the chart&apos;s data</span>
           </div>
 

--- a/src/components/device/loading/loading.component.js
+++ b/src/components/device/loading/loading.component.js
@@ -17,7 +17,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSpinner } from '@fortawesome/fontawesome-free-solid';
 
 export default class Loading extends React.Component {
   render() {
@@ -27,7 +26,7 @@ export default class Loading extends React.Component {
       <div className="row mt-3">
         <div className="col">
           <div className="text-center h4">
-            <FontAwesomeIcon icon={faSpinner} spin />
+            <FontAwesomeIcon icon="spinner" spin />
             <span className="ml-3">Loading {deviceName} data...</span>
           </div>
         </div>

--- a/src/components/device/missing/missing.component.js
+++ b/src/components/device/missing/missing.component.js
@@ -17,7 +17,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCommentAlt } from '@fortawesome/fontawesome-free-regular';
 
 export default class Missing extends React.Component {
   render() {
@@ -27,7 +26,7 @@ export default class Missing extends React.Component {
       <div className="row mt-3">
         <div className="col">
           <div className="text-center h4">
-            <FontAwesomeIcon icon={faCommentAlt} />
+            <FontAwesomeIcon icon="comment-alt" />
             <span className="ml-3">
               There is no available data under {projectName} project on {deviceName} device
             </span>

--- a/src/components/device/results/valid-result/summary/summary.component.js
+++ b/src/components/device/results/valid-result/summary/summary.component.js
@@ -17,7 +17,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCheckCircle, faTimesCircle, faArrowAltCircleRight, faClock } from '@fortawesome/fontawesome-free-regular';
 
 export default class Summary extends React.Component {
   render() {
@@ -38,25 +37,25 @@ export default class Summary extends React.Component {
     return (
       <div className="d-flex justify-content-between text-left">
         <div className="text-success pl-0" style={boxStyle} title="Passed">
-          <FontAwesomeIcon icon={faCheckCircle} className="mr-1" />
+          <FontAwesomeIcon icon="check-circle" className="mr-1" />
           <span>
             {pass}
           </span>
         </div>
         <div className="text-info" style={boxStyle} title="Timeout">
-          <FontAwesomeIcon icon={faClock} className="mr-1" />
+          <FontAwesomeIcon icon="clock" className="mr-1" />
           <span>
             {timeout}
           </span>
         </div>
         <div className="text-danger" style={boxStyle} title="Failed">
-          <FontAwesomeIcon icon={faTimesCircle} className="mr-1" />
+          <FontAwesomeIcon icon="times-circle" className="mr-1" />
           <span>
             {fail}
           </span>
         </div>
         <span className="text-warning" style={boxStyle} title="Skipped">
-          <FontAwesomeIcon icon={faArrowAltCircleRight} className="mr-1" />
+          <FontAwesomeIcon icon="arrow-alt-circle-right" className="mr-1" />
           <span>
             {skip}
           </span>

--- a/src/components/device/results/valid-result/valid-result.component.js
+++ b/src/components/device/results/valid-result/valid-result.component.js
@@ -17,7 +17,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronDown, faChevronUp } from '@fortawesome/fontawesome-free-solid';
 import Summary from './summary/summary.component';
 import Binary from './binary/binary.component';
 import Submodule from './submodule/submodule.component';
@@ -79,7 +78,7 @@ export default class ValidResult extends React.Component {
                 </span>
 
                 <div className="d-inline valid-collapse-button" onClick={this.handleCollapseClick}>
-                  <FontAwesomeIcon icon={collapsed ? faChevronDown : faChevronUp} />
+                  <FontAwesomeIcon icon={collapsed ? 'chevron-down' : 'chevron-up'} />
                 </div>
               </div>
             </div>

--- a/src/components/header/header.component.js
+++ b/src/components/header/header.component.js
@@ -17,7 +17,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faGithub } from '@fortawesome/fontawesome-free-brands';
 import ProjectSwitcher from './project-switcher/project-switcher.container';
 import MenuList from './menu-list/menu-list.component';
 import { devices, projects } from '../../constants';
@@ -55,7 +54,7 @@ export default class Header extends React.Component {
 
               <div className="ml-lg-auto">
                 <a className="nav-link text-light px-0" target="_blank" rel="noopener noreferrer" href={currentProject.url}>
-                  {currentProject.name} <FontAwesomeIcon icon={faGithub} />
+                  {currentProject.name} <FontAwesomeIcon icon={['fab', 'github']} />
                 </a>
               </div>
             </div>

--- a/src/fontawesome.js
+++ b/src/fontawesome.js
@@ -1,0 +1,34 @@
+import {
+  faExclamationTriangle,
+  faInfoCircle,
+  faSpinner,
+  faCommentAlt,
+  faChevronDown,
+  faChevronUp
+} from '@fortawesome/fontawesome-free-solid';
+import {
+  faCheckCircle,
+  faTimesCircle,
+  faArrowAltCircleRight,
+  faClock
+} from '@fortawesome/fontawesome-free-regular';
+import {
+  faGithub
+} from '@fortawesome/fontawesome-free-brands';
+
+export default [
+  // solid
+  faExclamationTriangle,
+  faInfoCircle,
+  faSpinner,
+  faCommentAlt,
+  faChevronDown,
+  faChevronUp,
+  // regular
+  faCheckCircle,
+  faTimesCircle,
+  faArrowAltCircleRight,
+  faClock,
+  //brands
+  faGithub
+];

--- a/src/index.js
+++ b/src/index.js
@@ -20,11 +20,15 @@ import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
 import { store } from './state/configure.store';
 import { history } from './side.effects/history';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import icons from './fontawesome';
 import routes from './routes';
 import 'bootstrap';
 import 'popper.js';
 
 import './style/index.scss';
+
+library.add(...icons);
 
 ReactDOM.render(
   <Provider store={store}>


### PR DESCRIPTION
The fontawesome icon imports now placed into one file.
With this solution we can avoid the double imports and only the
necessary icons will be imported into the build boundle.
In the components we can use the added icons with their text names.

IoT.js-Test-Results-DCO-1.0-Signed-off-by: Imre Kiss jakab.asd@gmail.com